### PR TITLE
fix: for markdown, decrease tabWidth

### DIFF
--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -31,7 +31,7 @@ const config: Config = {
             },
         },
         {
-            files: ["*.yaml", "*.yml"],
+            files: ["*.md", "*.yaml", "*.yml"],
             options: {
                 tabWidth: 2,
             },


### PR DESCRIPTION
Most importantly, this changes the tabWidth for embeddedLanguageFormatting
