### PR TITLE
feat!: expose explicit named exports from the entrypoint

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,8 @@
 /* eslint-disable unicorn/no-barrel-files -- package entrypoint */
-export * as checks from "./checks";
-export * from "./commands/base-program";
-export * from "./commands/cargo";
-export * from "./commands/cross";
-export * from "./commands/rustup";
-export * as input from "./input";
+export { Check } from "./checks";
+export { BaseProgram } from "./commands/base-program";
+export { Cargo } from "./commands/cargo";
+export { Cross } from "./commands/cross";
+export { RustUp } from "./commands/rustup";
+export type { ToolchainOptions } from "./commands/rustup";
+export { getInput, getInputAsArray, getInputBool, getInputList } from "./input";


### PR DESCRIPTION
Star re-exports publish anything later added to the underlying modules
without review, and a name exported by two starred modules is silently
excluded per ES semantics instead of erroring.

BREAKING CHANGE: the checks and input namespace exports are removed.
Import Check, getInput, getInputBool, getInputList and getInputAsArray
from the package root instead.